### PR TITLE
Allow for <teiCorpus>, too

### DIFF
--- a/fulltext/fulltext2table.enmasse.xq
+++ b/fulltext/fulltext2table.enmasse.xq
@@ -14,6 +14,12 @@ xquery version "3.0";
  : @author Ashley M. Clark, Northeastern University Women Writers Project
  : @version 1.3
  :
+ :  2018-11-29: Examine all <text> elements except those that are a
+ :              child of <group>. Add change-log comments. --Syd
+ :  2018-10-08: Allow a root element of <teiCorpus> as well as <TEI>.
+ :              Note that nested corpora are not searched through.
+ :              (I.e., we're looking at teiCorpus/TEI/text, not
+ :              teiCorpus//text which might be better.) --Syd
  :  2018-06-21: v.1.3. Added the external variable $preserve-space, which determines 
  :              whether whitespace is respected in the input XML document (the 
  :              default), or if steps are taken to normalize whitespace and add 
@@ -140,7 +146,7 @@ let $allRows :=
         return 
           ( $file, $idno, $author, $pubDate )
     (: Change $ELEMENTS to reflect the elements for which you want full-text representations. :)
-    let $ELEMENTS := /TEI/text|/teiCorpus/TEI/text
+    let $ELEMENTS := //text[not(parent::group)]
     (: Below, add the names of elements that you wish to remove from within $ELEMENTS.
      : For example, 
      :    ('castList', 'elision', 'figDesc', 'label', 'speaker')

--- a/fulltext/fulltext2table.xq
+++ b/fulltext/fulltext2table.xq
@@ -13,6 +13,23 @@ xquery version "3.0";
  : @author Ashley M. Clark, Northeastern University Women Writers Project
  : @version 1.3
  :
+ :  2018-12-01: Allow for outermost element of input document to be
+ :              <teiCorpus> in addition to <TEI>. Thus the sequence of
+ :              elements in $text may contain both <TEI> and
+ :              <teiCorpus>, and to look for the non-metadata bits
+ :              themselves we want to look for all <text> desendants,
+ :              not just child of outermost element. However, we don't
+ :              want to count a <text> more than once, so avoid nested
+ :              <text> elements by ignoring those that are within a
+ :              <group>. (Since <group> is definitionally a descendant
+ :              of <text>, all those will aready be collected by
+ :              catching the <text> that is the ancestor of the
+ :              <group>.)
+ :  2018-11-29: Bug fix (by SB on phone w/ AC): fix assignment of
+ :              $header (to the <teiHeader> child of the outermost
+ :              element, recorded in $text, rather than to the
+ :              non-existant <teiHeader> child of the <TEI> child of
+ :              the element recorded in $text).
  :  2018-06-21: v.1.3. Added the external variable $preserve-space, which determines 
  :              whether whitespace is respected in the input XML document (the 
  :              default), or if steps are taken to normalize whitespace and add 
@@ -125,12 +142,12 @@ let $allRows :=
     if ( $return-only-words ) then ()
     else local:make-cells-in-row($headerRow),
     
-    for $text in $use-docs/TEI
+    for $text in $use-docs/TEI | $use-docs/teiCorpus
     let $file := tokenize($text/base-uri(),'/')[last()]
     let $optionalMetadata :=
       if ( $return-only-words ) then ()
       else
-        let $header := $text/TEI/teiHeader
+        let $header := $text/teiHeader
         let $idno := $header/fileDesc/publicationStmt/idno[@type eq 'WWP']/data(.)
         let $author := $header/fileDesc/titleStmt/author[1]/persName[@ref][1]/@ref/substring-after(data(.),'p:')
         let $pubDate := 
@@ -142,7 +159,7 @@ let $allRows :=
         return 
           ( $file, $idno, $author, $pubDate )
     (: Change $ELEMENTS to reflect the elements for which you want full-text representations. :)
-    let $ELEMENTS := $text/text
+    let $ELEMENTS := $text//text[not(parent::group)]
     (: Below, add the names of elements that you wish to remove from within $ELEMENTS.
      : For example, 
      :    ('castList', 'elision', 'figDesc', 'label', 'speaker')

--- a/tagsDecl/find_specific_renditional_defaults.xslt
+++ b/tagsDecl/find_specific_renditional_defaults.xslt
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xpath-default-namespace="http://www.tei-c.org/ns/1.0"
+  version="3.0">
+  
+  <!-- Copyleft 2018 Syd Bauman and the Women Writers Project -->
+  
+  <!--
+    NOTE: There is a more WWP-specific version of this
+    program in [TB]/stylesheets/.
+  -->
+
+  <!--
+    Read in a TEI document, and write out the default rendition(s)
+    that match a specified GI. GIs may be specified on the commandline
+    via the $GIs parameter. (A sequence of strings that should match the
+    requirements of xs:NCName or '*', but are actually xs:string(s).)
+  -->
+
+  <!--
+    Example usage on a single file:
+    $ saxon -xsl:/path/to/find_specific_renditional_defaults.xslt -s:distribution/elizabeth.lastspeech.xml -o:/dev/null/ '?GIs=("fw","pb","milestone","div")'
+    Example usage on a directory:
+    $ saxon -xsl:/path/to/find_specific_renditional_defaults.xslt -s:INPUTdir/ -o:/tmp/OUTPUTdir/ '?GIs=("fw","pb","milestone","div")'; done
+    Note that in the single file case we can just toss away the output
+    by sending it to /dev/null; but we can't do that in the directory-
+    at-a-time case, because Saxon requires that if -s: is a directory
+    then so must -o: be.
+  -->
+
+  <!-- The elements to look for as a sequence of GIs (i.e., element names) -->
+  <xsl:param select="('p','bibl')" name="GIs" as="xs:string+"/>
+  <xsl:variable name="universal" select="$GIs = '*'" as="xs:boolean"/>
+  <!-- Get the name of the input file (and its directory) for future use -->
+  <xsl:variable name="inputDir" select="tokenize( base-uri(/),'/')[last()-1]"/>
+  <xsl:variable name="inputFile" select="tokenize( base-uri(/),'/')[last()]"/>
+
+  <!--
+    Proclaim our output as simple text just to keep output files smaller
+    (no XML declaration). Actually, there is no useful output to STDOUT
+    at all. All useful information goes to STDERR via <xsl:message>
+    instructions.
+  -->
+  <xsl:output method="text"/>
+  
+  <xsl:template match="/">
+    <!-- Process only the bits of the document we are interested in -->
+    <xsl:apply-templates select="/TEI/teiHeader/encodingDesc//rendition"/>
+    <xsl:text>&#x0A;</xsl:text>
+  </xsl:template>
+
+  <xsl:template match="rendition">
+    <!--
+      Get our content for reporting later. Notes:
+      1) We won't be able to just use '.' later, because by the time we want access
+         to this information the context node will have changed.
+      2) We normalize the space for readability. But if you have rendition ladders
+         that have significant space within (e.g., "fill(.  )"), you probably don't
+         want that.
+    -->
+    <xsl:variable name="content" select="normalize-space(.)"/>
+    <!-- Parse out individual selectors from a group of selectors. -->
+    <xsl:variable name="selectors" select="for $s in tokenize( @selector,',') return normalize-space($s)"/>
+    <!-- Now iterate over each individual selector, and for each of 'em ... -->
+    <xsl:for-each select="$selectors">
+      <!--
+        ... check to see if one of the GIs of interest appears. Note that this simple
+        test works for us because we have only type selectors, never an attribute
+        selector, class selector, ID selector, pseudo-element, or a pseudo-class.
+        In fact, we never use an adjacent ('+') or general ('~') sibling cominator,
+        either, but there's no harm checking for 'em.
+      -->
+      <xsl:if test="$universal  or  tokenize( .,'[&#x20;&gt;+~]+') = $GIs">
+        <!--
+          So that test above first checks to see if user asked for '*', the
+          universal selector; if so, test succeeds. If not, it then chops
+          the selector we are examining into a sequences of simple selectors,
+          and compares each simple selector to each requested GI. If any one
+          on L matches any one on R, test succeeds.
+        -->
+        <xsl:message select="'---------'||$inputDir||'/'||$inputFile||' | selector='||.||' | '||$content"/>
+      </xsl:if>
+    </xsl:for-each>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/tagsDecl/generate_tagsDecl.xslt
+++ b/tagsDecl/generate_tagsDecl.xslt
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- generate_tagsDecl.xslt -->
+<!-- Read in a TEI P5 document and write out a <tagsDecl> element that -->
+<!-- reflects its encoding. -->
+<!-- Copyleft 2009 by Syd Bauman and the Women Writers Project -->
+<!-- Based very heavily on James Cummings' Count-Elements.xsl at -->
+<!-- http://wiki.tei-c.org/index.php/Count-Elements.xsl 2009-07-06 -->
+<!-- Updated 2018-12-04 by Syd: improve how we collect <text> elements to
+     examine. (We were missing those nested in teiCorpus/teiCorpus.) -->
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns="http://www.tei-c.org/ns/1.0"
+  xmlns:tei="http://www.tei-c.org/ns/1.0">
+  
+  <xsl:output method="xml" indent="yes"/>
+  
+  <!-- Generate a key for element names (local). --> 
+  <!-- A Perlese example of the use of this key would be-->
+  <!-- $gis{emph}, which reference would return a nodeset -->
+  <!-- of all the <*:emph> nodes, I think -->
+  <xsl:key name="gis" use="local-name()"
+    match="//tei:TEI/tei:text//*"/>
+  <!-- Generate a key for element namespaces. --> 
+  <!-- A Perlese example of the use of this key would be-->
+  <!-- $nss{svg}, which reference would return a nodeset -->
+  <!-- of all the namespace URIs of <*:svg> nodes, I think -->
+  <xsl:key name="nss" use="namespace-uri()" match="//tei:TEI/tei:text//*"/>
+  
+  <xsl:template match="/">
+    <!-- Since the <tagsDecl> talks about the elements "occurring within the -->
+    <!-- outermost <text> element of a TEI document", we only want to match the -->
+    <!-- outermost <text> element(s), i.e. children of <TEI>, regardless of -->
+    <!-- how deeply nested within <teiCorpus> elements that <TEI> is. -->
+    <xsl:apply-templates select="//tei:TEI/tei:text"/>
+  </xsl:template>
+  
+  <xsl:template match="tei:text">
+    <!-- generate an output tagging declaration for each input <text> -->
+    <tagsDecl>
+      <!-- process each node that is the first one in a set of nodes with the same namespace -->
+      <xsl:for-each select="//*[generate-id(.)=generate-id(key('nss',namespace-uri(.))[1])]">
+        <!-- keep sorted by said namesapce -->
+        <xsl:sort select="namespace-uri()"/>
+        <!-- and remember said namespace for easy reference -->
+        <xsl:variable name="ns" select="namespace-uri()"/>
+        <!-- output a <namespace> element in which to list the elemenst used in this namespace -->
+        <namespace name="{$ns}">
+          <!-- process each node that has this namespace and is the first one in the set of nodes with the same -->
+          <!-- local name -->
+          <xsl:for-each select="//*[namespace-uri(.)=$ns][generate-id(.)=generate-id(key('gis',local-name(.))[1])]">
+            <!-- sort by the local name -->
+            <xsl:sort select="local-name()"/>
+            <!-- putput a <tagUsage> element that gives counts for the number -->
+            <!-- of similarly named descendants of <text> and number of those -->
+            <!-- that are identified with xml:id=. -->
+            <tagUsage gi="{local-name(.)}"
+              occurs="{count( key('gis', local-name(.) ) )}"
+              withId="{count( key('gis', local-name(.) )[@xml:id] )}"/>
+          </xsl:for-each>
+        </namespace>
+      </xsl:for-each>
+    </tagsDecl>
+  </xsl:template>
+  
+</xsl:stylesheet>


### PR DESCRIPTION
I've tested on one set of 3 files:

 0. standard TEI-teiHeader-text structure
 1. TEI-teiHeader-text-group-text structure
 2. teiCorpus-teiHeader-TEI-text structure

Quick counts of the result say it seems to work.