### PR TITLE
Build out counting robot library (v1.2)

### DIFF
--- a/counts/README.md
+++ b/counts/README.md
@@ -108,21 +108,45 @@ You should feel free to change the default namespace and/or add namespace prefix
 The Counting Robot uses XQuery version 3.0. Since it is assumed you'll be working extensively in the declared variables, the XQuery script has no external parameters to set. See our general documentation for details on [setting up an XQuery transformation](../docs/setup-xquery.md).
 
 
-## The set theory library
+## The counting sets library
 
-Unlike the Counting Robot, `count-sets-library.xql` is library of XQuery functions, rather than a standalone XQuery. The functions can be used to combine and manipulate multiple reports from the Counting Robot:
+Unlike the Counting Robot, `count-sets-library.xql` is library of XQuery functions, rather than a standalone XQuery. It contains functions that replicate the behavior of the standalone XQueries, as well as functions that can be used to combine and manipulate multiple reports from the Counting Robot.
+
+### Available functions
+
+#### TSV manipulation
+
+* `ctab:create-row-match-pattern( ($value1, $value2, $value3) )`
+  * Given a sequence of string values, returns a string regular expression which can be used to match a subset of rows.
+* `ctab:get-cell( $row, $cell-number )`
+  * Get the contents of the requested cell from the given TSV row.
+* `ctab:get-report-by-lines( $filepath )`
+  * Get a TSV file and return the lines containing a tab character.
+  * This is a convenience function for `fn:unparsed-text-lines()`.
+* `ctab:join-rows( ($row1, $row2, $ETC) )`
+  * Given a sequence of strings, joins them with a newline character in order to form a single report.
+
+#### Counting
+
+* `ctab:get-counts( ($results) )`
+  * Given a sequence of results from a prior XQuery, returns a tab-delimited report of the distinct values and their counts.
+  * By default, the rows of the report are sorted by count, then alphabetically by value.
+* `ctab:get-sortable-string( "String" )`
+  * Use the given string to create a version optimized for sorting alphabetically. Some non-sorting articles ("the", "an", etc.) are removed.
+
+#### Set theory
 
 * `ctab:get-union-of-reports( ($filenameA, $filenameB, $ETC) )`
-  * the union of reports A through N in a sequence (including adding up the counts)
+  * Get the union of reports A through N in a sequence (including adding up the counts).
 * `ctab:get-union-of-rows( ($rowA1, $rowB1, $ETC) )`
-  * the union of all rows in a sequence (including adding up the counts)
+  * Get the union of all rows in a sequence (including adding up the counts).
 * `ctab:get-intersection-of-reports( ($filenameA, $filenameB, $ETC) )`
-  * the intersection of reports A through N, or, only the data values which occur once per report (including adding up the counts)
+  * Get the intersection of reports A through N, or, only the data values which occur once per report (including adding up the counts).
 * `ctab:get-set-difference-of-reports($filenameA, $filenameB)`
-  * all data values in report(s) A where there isn't a corresponding value in report(s) B
-  * both A and B can be a sequence of filenames rather than a single string; the union of those sequences will be applied automatically
+  * Get all data values in report(s) A where there isn't a corresponding value in report(s) B.
+  * Both A and B can be a sequence of filenames rather than a single string; the union of those sequences will be applied automatically.
 * `ctab:get-set-difference-of-rows( ($rowA1, $rowA2, $ETC), ($rowB1, $rowB2, $ETC) )`
-  * all data values in the sequence of rows A where there isn't a corresponding value in sequence of rows B
+  * Get all data values in the sequence of rows A where there isn't a corresponding value in sequence of rows B.
 
 <!--### Importing the library-->
 

--- a/counts/count-sets-library.xql
+++ b/counts/count-sets-library.xql
@@ -25,8 +25,10 @@ xquery version "3.0";
  :        value in sequence of rows B
  :
  : @author Ashley M. Clark, Northeastern University Women Writers Project
+ : @see https://github.com/NEU-DSG/wwp-public-code-share/tree/master/counts
  : @version 1.2
  :
+ :  2018-12-20: Added link to GitHub.
  :  2018-08-01: v1.2. Added ctab:get-counts(), three function versions of 
  :    counting-robot.xq. Also added ctab:get-sortable-string() to support 
  :    ctab:get-counts().

--- a/counts/count-sets-library.xql
+++ b/counts/count-sets-library.xql
@@ -40,14 +40,14 @@ xquery version "3.0";
  :)
 
 (: NAMESPACES :)
-module namespace ctab="http://www.wwp.northeastern.edu/ns/count-sets/functions";
-declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
+  module namespace ctab="http://www.wwp.northeastern.edu/ns/count-sets/functions";
+  declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
 
 
 (: VARIABLES :)
-declare variable $ctab:tabChar      := '&#9;';
-declare variable $ctab:newlineChar  := '&#13;';
-declare variable $ctab:nonsortRegex := '^(the|an|a|la|le|de|del|el|lo|las|los) ';
+  declare variable $ctab:tabChar      := '&#9;';
+  declare variable $ctab:newlineChar  := '&#13;';
+  declare variable $ctab:nonsortRegex := '^(the|an|a|la|le|de|del|el|lo|las|los) ';
 
 
 (: FUNCTIONS :)
@@ -173,9 +173,11 @@ declare function ctab:get-set-difference-of-rows($tabbed-rows as xs:string+, $ro
     $rowsWithTabs[not(matches(.,$regex))]
 };
 
-(:~  :)
+(:~ Given a string, create a version for alphabetical sorting. Spaces are 
+  normalized, characters are lower-cased, and non-sorting articles from 
+  $ctab:nonsortRegex are removed. :)
 declare function ctab:get-sortable-string($str as xs:string) {
-  replace(lower-case(normalize-space($str)), $ctab:nonsortRegex,'')
+  replace(lower-case(normalize-space($str)), $ctab:nonsortRegex, '')
 };
 
 (:~ Combine the counts for all values in N tab-delimited reports. :)

--- a/counts/counting-robot.enmasse.xq
+++ b/counts/counting-robot.enmasse.xq
@@ -10,8 +10,10 @@ xquery version "3.0";
  : @return tab-delimited text
  :
  : @author Ashley M. Clark, Northeastern University Women Writers Project
+ : @see https://github.com/NEU-DSG/wwp-public-code-share/tree/master/counts
  : @version 1.1
  :
+ :  2018-12-20: Added link to GitHub.
  :  2018-08-01: v1.1. Added some nonsortable articles.
  :  2017-11-16: Created using counting-robot.xq v1.0.
  :)

--- a/counts/counting-robot.enmasse.xq
+++ b/counts/counting-robot.enmasse.xq
@@ -10,8 +10,9 @@ xquery version "3.0";
  : @return tab-delimited text
  :
  : @author Ashley M. Clark, Northeastern University Women Writers Project
- : @version 1.0
+ : @version 1.1
  :
+ :  2018-08-01: v1.1. Added some nonsortable articles.
  :  2017-11-16: Created using counting-robot.xq v1.0.
  :)
 
@@ -55,7 +56,7 @@ declare option output:method "text";
   It also lower-cases the string, since capital letters will have an effect on 
   sort order. :)
 declare function local:get-sortable-string($str as xs:string) {
-  replace(lower-case(normalize-space($str)), '^(the|an|a|la|le|el|lo|las|los) ','')
+  replace(lower-case(normalize-space($str)), '^(the|an|a|la|le|de|del|el|lo|las|los) ','')
 };
 
 (: THE COUNTING ROBOT :)

--- a/counts/counting-robot.xq
+++ b/counts/counting-robot.xq
@@ -6,8 +6,10 @@ xquery version "3.0";
  : @return tab-delimited text
  :
  : @author Ashley M. Clark, Northeastern University Women Writers Project
+ : @see https://github.com/NEU-DSG/wwp-public-code-share/tree/master/counts
  : @version 1.1
  :
+ :  2018-12-20: Added link to GitHub.
  :  2018-08-01: v1.1. Added some nonsortable articles.
  :  2017-06-30: v1.0. Added this header and changelog.
  :  2017-04-28: Moved script from Gist to wwp-public-code-share git repository.

--- a/counts/counting-robot.xq
+++ b/counts/counting-robot.xq
@@ -6,8 +6,9 @@ xquery version "3.0";
  : @return tab-delimited text
  :
  : @author Ashley M. Clark, Northeastern University Women Writers Project
- : @version 1.0
+ : @version 1.1
  :
+ :  2018-08-01: v1.1. Added some nonsortable articles.
  :  2017-06-30: v1.0. Added this header and changelog.
  :  2017-04-28: Moved script from Gist to wwp-public-code-share git repository.
  :  2017-04-13: Added default element namespace declaration.
@@ -58,7 +59,7 @@ declare option output:method "text";
   It also lower-cases the string, since capital letters will have an effect on 
   sort order. :)
 declare function local:get-sortable-string($str as xs:string) {
-  replace(lower-case(normalize-space($str)), '^(the|an|a|la|le|el|lo|las|los) ','')
+  replace(lower-case(normalize-space($str)), '^(the|an|a|la|le|de|del|el|lo|las|los) ','')
 };
 
 (: THE COUNTING ROBOT :)

--- a/fulltext/fulltext2table.enmasse.xq
+++ b/fulltext/fulltext2table.enmasse.xq
@@ -15,6 +15,7 @@ xquery version "3.0";
  : @see https://github.com/NEU-DSG/wwp-public-code-share/tree/master/fulltext
  : @version 1.4
  :
+ :  2018-12-20: v.1.4. Added link to GitHub.
  :  2018-11-29: Examine all <text> elements except those that are a
  :              child of <group>. Add change-log comments. --Syd
  :  2018-10-08: Allow a root element of <teiCorpus> as well as <TEI>.

--- a/fulltext/fulltext2table.enmasse.xq
+++ b/fulltext/fulltext2table.enmasse.xq
@@ -12,7 +12,8 @@ xquery version "3.0";
  : @return tab-delimited text
  :
  : @author Ashley M. Clark, Northeastern University Women Writers Project
- : @version 1.3
+ : @see https://github.com/NEU-DSG/wwp-public-code-share/tree/master/fulltext
+ : @version 1.4
  :
  :  2018-11-29: Examine all <text> elements except those that are a
  :              child of <group>. Add change-log comments. --Syd

--- a/fulltext/fulltext2table.xq
+++ b/fulltext/fulltext2table.xq
@@ -11,7 +11,8 @@ xquery version "3.0";
  : @return tab-delimited text
  :
  : @author Ashley M. Clark, Northeastern University Women Writers Project
- : @version 1.3
+ : @see https://github.com/NEU-DSG/wwp-public-code-share/tree/master/fulltext
+ : @version 1.4
  :
  :  2018-12-01: Allow for outermost element of input document to be
  :              <teiCorpus> in addition to <TEI>. Thus the sequence of

--- a/fulltext/fulltext2table.xq
+++ b/fulltext/fulltext2table.xq
@@ -14,6 +14,7 @@ xquery version "3.0";
  : @see https://github.com/NEU-DSG/wwp-public-code-share/tree/master/fulltext
  : @version 1.4
  :
+ :  2018-12-20: v.1.4. Added link to GitHub.
  :  2018-12-01: Allow for outermost element of input document to be
  :              <teiCorpus> in addition to <TEI>. Thus the sequence of
  :              elements in $text may contain both <TEI> and


### PR DESCRIPTION
Makes functions out of the counting robot XQueries. The original XQueries continue to work on their own, without the library module.