### PR TITLE
Tweak for WWP output:

### DIFF
--- a/character_counts/table_of_Unicode_codepoint_counts.xslt
+++ b/character_counts/table_of_Unicode_codepoint_counts.xslt
@@ -516,7 +516,7 @@
                 </ul>
               </xsl:when>
               <xsl:when test="$input/wwp:* | $input/yaps:*">
-                keep only pre() and post() of @rend
+                keep only pre() and post() of @rend, and ignore keywords like “#rule” in those
               </xsl:when>
               <xsl:when test="$input/html:*">
                 keep only @title and @alt

--- a/character_counts/table_of_Unicode_codepoint_counts.xslt
+++ b/character_counts/table_of_Unicode_codepoint_counts.xslt
@@ -330,6 +330,8 @@
     <xsl:if test="self::attribute(rend)">
       <xsl:if test="matches( .,'p(re|ost)\(')">
         <xsl:variable name="rend" select="."/>
+        <!-- Remove keywords ’cause they are not characters -->
+        <xsl:variable name="rend" select="replace( $rend, '#[A-Za-z0-9._-]+','')"/>
         <xsl:variable name="rend" select="replace( $rend, $rlops, $pop )"/>
         <xsl:variable name="rend" select="replace( $rend, $rlcps, $pcp )"/>
         <xsl:variable name="pre">


### PR DESCRIPTION
Remove keywords (which start with a ‘#’) from rend= attributes in WWP files when $attr is 1.