### PR TITLE
No duplicate history; fix missing filename; use commas in counts themselves

### DIFF
--- a/character_counts/table_of_Unicode_codepoint_counts.xslt
+++ b/character_counts/table_of_Unicode_codepoint_counts.xslt
@@ -27,7 +27,7 @@
   <xsl:param name="fold" select="0" as="xs:integer"/>
   <xsl:param name="skip" select="3" as="xs:integer"/>
   <xsl:param name="whitespace" select="0" as="xs:integer"/>
-  <xsl:param name="fileName" select="tokenize( base-uri(/), '/')[last()]"/>
+  <xsl:param name="fileName" select="tokenize(base-uri(/), '/')[last()]"/>
   <xd:doc>
     <xd:desc>protect open paren, protect close paren: theses variables should
       each be set to any single character you <xd:b>know</xd:b> will not be in the input
@@ -254,7 +254,7 @@
               <xsl:variable name="hexNum4digit" select="substring('0000', string-length($hexNum) + 1)||$hexNum"/>
               <tr>
                 <td class="cnt">
-                  <xsl:value-of select="$count_by_decimal_char_num(.)"/>
+                  <xsl:value-of select="$count_by_decimal_char_num(.) => format-integer('###,###,###,##0')"/>
                 </td>
                 <td class="Ucp">
                   <xsl:value-of select="'U+'||$hexNum4digit"/>
@@ -271,11 +271,10 @@
             </xsl:for-each>
           </tbody>
         </table>
-        <p>Total characters: <xsl:sequence select="format-number( count( $seq ),'#,###,###,##0')"/>.
-        <br/>Distinct characters: <xsl:sequence select="format-number( map:size($count_by_decimal_char_num),'#,###,##0')"/>.</p>
+        <p>Total characters counted: <xsl:sequence select="format-number( count( $seq ),'#,###,###,##0')"/>.</p>
         <p>This table generated <xsl:value-of select="current-dateTime()"/>.</p>
         <hr/>
-        <p xsl:expand-text="yes"><a name="fn1">¹</a> {$me}.</p>
+        <p name="fn1">¹ <xsl:value-of select="base-uri(/)"/></p>
       </body>
     </html>
   </xsl:template>
@@ -331,8 +330,6 @@
     <xsl:if test="self::attribute(rend)">
       <xsl:if test="matches( .,'p(re|ost)\(')">
         <xsl:variable name="rend" select="."/>
-        <!-- Remove keywords ’cause they are not characters -->
-        <xsl:variable name="rend" select="replace( $rend, '#[A-Za-z0-9._-]+','')"/>
         <xsl:variable name="rend" select="replace( $rend, $rlops, $pop )"/>
         <xsl:variable name="rend" select="replace( $rend, $rlcps, $pcp )"/>
         <xsl:variable name="pre">
@@ -391,17 +388,16 @@
   <xd:doc>
     <xd:desc>
       <xd:p>Given a code point, return the Unicode name(s) of a character.</xd:p>
-      <xd:p>In the UCD, each character (other than those in certain
-      groups of CJK, Tangut, or Nüshu ideographic characters) has at
-      least one name; many have two names. The names are typically
-      expressed on the <code>@na</code> attribute, and second names on
-      the <code>@na1</code> attribute. But in some cases the only one
-      name is expressed on <code>@na1</code>. Furthermore, when a name
-      is not expressed on a <code>@na</code> or <code>@na1</code>
-      attribute, sometimes the attribute is still present but just has
-      no value. However, <code>@na</code> is only specified without a
-      value for characters we should never see: DELETE and the PUA
-      block.</xd:p>
+      <xd:p>In the UCD, each character (other than those in certain groups of
+      CJK, Tangut, or Nüshu ideographic characters) has at least one name;
+      many have two names. The names are typically expressed on the
+      <tt>@na</tt> attribute, and second names on the <tt>@na1</tt>
+      attribute. But in some cases the only one name is expressed on
+      <tt>@na1</tt>. Furthermore, when a name is not expressed on a
+      <tt>@na</tt> or <tt>@na1</tt> attribute, sometimes the attribute
+      is still present but just has no value. However, <tt>@na</tt>
+      is only specified without a value for characters we should never
+      see: DELETE and the PUA block.</xd:p>
     </xd:desc>
     <xd:param name="thisCodePoint">a 4-digit positive hexadecimal integer
       (expressed as a 4-character long xs:string).</xd:param>
@@ -414,6 +410,7 @@
     <xsl:choose>
       <xsl:when test="not( exists( $thisChar) )">
         <xsl:variable name="msg" select="'Unable to ascertain Unicode name for '||$thisCodePoint"/>
+        <xsl:message select="$msg"/>
         <xsl:value-of select="$msg"/>
       </xsl:when>
       <!-- both @na and @na1 -->
@@ -445,10 +442,11 @@
   </xd:doc>
   <xsl:template name="html_head">
     <head>
-      <title xsl:expand-text="yes">Character counts in {$fileName}</title>
+      <xsl:variable name="title" select="'chars in '||$fileName"/>
+      <title><xsl:value-of select="'Character counts in '||$fileName"/></title>
       <meta name="generated_by" content="table_of_Unicode_codepoint_counts.xslt"/>
       <meta name="generated_at" content="{current-dateTime()}"/>
-      <script type="application/javascript" src="https://www.wwp.neu.edu/utils/bin/javascript/sorttable.js"/>
+      <script type="application/javascript" src="http://www.wwp.neu.edu/utils/bin/javascript/sorttable.js"/>
       <style type="text/css">
         <xsl:text disable-output-escaping="yes">
             body {
@@ -495,14 +493,14 @@
     used, and indicates which were actually used.</xd:desc>
   </xd:doc>
   <xsl:template name="explain_params">
-    <p>Character counts in
-      <code xsl:expand-text="yes">{$fileName}</code><a href="#fn1">¹</a>,
-      using the following parameters:</p>
+    <p>Character counts in <tt><xsl:value-of
+      select="$fileName"/></tt><a href="#fn1">¹</a>, using the
+      following parameters:</p>
     <dl>
       <dt><span class="param">attrs</span></dt>
       <dd>
         <ul>
-          <li class="{$attrs eq 0}"><span class="val">0</span>: drop <em>all</em> attributes</li>
+          <li class="{$attrs eq 0}"><span class="val">0</span>: drop <emph>all</emph> attributes</li>
           <li class="{$attrs eq 1}"><span class="val">1</span>: 
             <xsl:choose>
               <xsl:when test="$input/tei:*">
@@ -516,7 +514,7 @@
                 </ul>
               </xsl:when>
               <xsl:when test="$input/wwp:* | $input/yaps:*">
-                keep only pre() and post() of @rend, and ignore keywords like “#rule” in those
+                keep only pre() and post() of @rend
               </xsl:when>
               <xsl:when test="$input/html:*">
                 keep only @title and @alt
@@ -529,7 +527,7 @@
               </xsl:otherwise>
             </xsl:choose> [default]
           </li>
-          <li class="{$attrs eq 9}"><span class="val">9</span>: keep <em>all</em> attributes</li>
+          <li class="{$attrs eq 9}"><span class="val">9</span>: keep <emph>all</emph> attributes</li>
         </ul>
       </dd>
       <dt><span class="param">fold</span></dt>
@@ -544,20 +542,14 @@
       <dt><span class="param">skip</span></dt>
       <dd>
         <ul>
-          <li class="{$skip eq 0}"><span class="val">0</span>:
-            process entire document, including comments and processing instructions</li>
-          <li class="{$skip eq 1}"><span class="val">1</span>:
-            process entire document <em>excluding</em> comments and processing instructions</li>
-          <li class="{$skip eq 2}"><span class="val">2</span>:
-            do 1, and also strip out metadata (<code>&lt;teiHeader></code> or <code>&lt;html:head></code>)</li>
-          <li class="{$skip eq 3}"><span class="val">3</span>:
-            do 2, and also strip out printing artifacts, etc. (<code>&lt;tei:fw></code>, <code>&lt;wwp:mw></code>, <code>&lt;figDesc></code>) [default]</li>
-          <li class="{$skip eq 4}"><span class="val">4</span>:
-            do 3, and also take <code>&lt;corr&gt;</code> over <code>&lt;sic&gt;</code>, <code>&lt;expan&gt;</code> over
-            <code>&lt;abbr&gt;</code>, <code>&lt;reg&gt;</code> over <code>&lt;orig&gt;</code> and the first
-            <code>&lt;supplied&gt;</code> or <code>&lt;unclear&gt;</code> in a <code>&lt;choice&gt;</code> (only makes
-            sense for TEI and WWP; and for WWP this means counting the regularized version of each <code>&lt;vuji></code>
-            character)</li>
+          <li class="{$skip eq 0}"><span class="val">0</span>: process entire document, including comments and processing instructions</li>
+          <li class="{$skip eq 1}"><span class="val">1</span>: process entire document <em>excluding</em> comments and processing instructions</li>
+          <li class="{$skip eq 2}"><span class="val">2</span>: do 1, and also strip out metadata (<tt>&lt;teiHeader></tt> or <tt>&lt;html:head></tt>)</li>
+          <li class="{$skip eq 3}"><span class="val">3</span>: do 2, and also strip out printing artifacts, etc. (<tt>&lt;tei:fw></tt>, <tt>&lt;wwp:mw></tt>, <tt>&lt;figDesc></tt>) [default]</li>
+          <li class="{$skip eq 4}"><span class="val">4</span>: do 3, and also take <tt>&lt;corr&gt;</tt> over <tt>&lt;sic&gt;</tt>, <tt>&lt;expan&gt;</tt> over
+            <tt>&lt;abbr&gt;</tt>, <tt>&lt;reg&gt;</tt> over <tt>&lt;orig&gt;</tt> and the first <tt>&lt;supplied&gt;</tt> or
+            <tt>&lt;unclear&gt;</tt> in a <tt>&lt;choice&gt;</tt> (only makes sense for TEI and WWP; and for WWP this
+            means counting the regularized version of each <tt>&lt;vuji></tt> character)</li>
         </ul>
       </dd>
       <dt><span class="param">whitespace</span></dt>

--- a/character_counts/table_of_Unicode_codepoint_counts.xslt
+++ b/character_counts/table_of_Unicode_codepoint_counts.xslt
@@ -514,7 +514,7 @@
                 </ul>
               </xsl:when>
               <xsl:when test="$input/wwp:* | $input/yaps:*">
-                keep only pre() and post() of @rend
+                keep only pre() and post() of @rend, and ignore keywords like “#rule” in those
               </xsl:when>
               <xsl:when test="$input/html:*">
                 keep only @title and @alt

--- a/character_counts/table_of_Unicode_codepoint_counts.xslt
+++ b/character_counts/table_of_Unicode_codepoint_counts.xslt
@@ -272,7 +272,7 @@
           </tbody>
         </table>
         <p>Total characters counted: <xsl:sequence select="format-number( count( $seq ),'#,###,###,##0')"/>.
-        <br/>Distinct characters: <xsl:sequence select="format-number(map:size( $count_by_decimal_char_num ),'#,###,##0')"/>.</p>
+        <br/>Distinct characters counted: <xsl:sequence select="format-number( map:size( $count_by_decimal_char_num ),'#,###,##0')"/>.</p>
         <p>This table generated <xsl:value-of select="current-dateTime()"/>.</p>
         <hr/>
         <p xsl:expand-text="yes"><a name="fn1">¹</a> {$me}.</p>
@@ -495,7 +495,7 @@
     used, and indicates which were actually used.</xd:desc>
   </xd:doc>
   <xsl:template name="explain_params">
-  <p>Character counts in
+    <p>Character counts in
       <code xsl:expand-text="yes">{$fileName}</code><a href="#fn1">¹</a>,
       using the following parameters:</p>
     <dl>

--- a/character_counts/table_of_Unicode_codepoint_counts.xslt
+++ b/character_counts/table_of_Unicode_codepoint_counts.xslt
@@ -514,7 +514,7 @@
                 </ul>
               </xsl:when>
               <xsl:when test="$input/wwp:* | $input/yaps:*">
-                keep only pre() and post() of @rend, and ignore keywords like “#rule” in those
+                keep only pre() and post() of @rend
               </xsl:when>
               <xsl:when test="$input/html:*">
                 keep only @title and @alt

--- a/character_counts/table_of_Unicode_codepoint_counts.xslt
+++ b/character_counts/table_of_Unicode_codepoint_counts.xslt
@@ -27,7 +27,7 @@
   <xsl:param name="fold" select="0" as="xs:integer"/>
   <xsl:param name="skip" select="3" as="xs:integer"/>
   <xsl:param name="whitespace" select="0" as="xs:integer"/>
-  <xsl:param name="fileName" select="tokenize(base-uri(/), '/')[last()]"/>
+  <xsl:param name="fileName" select="tokenize( base-uri(/), '/')[last()]"/>
   <xd:doc>
     <xd:desc>protect open paren, protect close paren: theses variables should
       each be set to any single character you <xd:b>know</xd:b> will not be in the input
@@ -271,10 +271,11 @@
             </xsl:for-each>
           </tbody>
         </table>
-        <p>Total characters counted: <xsl:sequence select="format-number( count( $seq ),'#,###,###,##0')"/>.</p>
+        <p>Total characters counted: <xsl:sequence select="format-number( count( $seq ),'#,###,###,##0')"/>.
+        <br/>Distinct characters: <xsl:sequence select="format-number(map:size( $count_by_decimal_char_num ),'#,###,##0')"/>.</p>
         <p>This table generated <xsl:value-of select="current-dateTime()"/>.</p>
         <hr/>
-        <p name="fn1">¹ <xsl:value-of select="base-uri(/)"/></p>
+        <p xsl:expand-text="yes"><a name="fn1">¹</a> {$me}.</p>
       </body>
     </html>
   </xsl:template>
@@ -330,6 +331,8 @@
     <xsl:if test="self::attribute(rend)">
       <xsl:if test="matches( .,'p(re|ost)\(')">
         <xsl:variable name="rend" select="."/>
+        <!-- Remove keywords ’cause they are not characters -->
+        <xsl:variable name="rend" select="replace( $rend, '#[A-Za-z0-9._-]+','')"/>
         <xsl:variable name="rend" select="replace( $rend, $rlops, $pop )"/>
         <xsl:variable name="rend" select="replace( $rend, $rlcps, $pcp )"/>
         <xsl:variable name="pre">
@@ -391,11 +394,11 @@
       <xd:p>In the UCD, each character (other than those in certain groups of
       CJK, Tangut, or Nüshu ideographic characters) has at least one name;
       many have two names. The names are typically expressed on the
-      <tt>@na</tt> attribute, and second names on the <tt>@na1</tt>
+      <code>@na</code> attribute, and second names on the <code>@na1</code>
       attribute. But in some cases the only one name is expressed on
-      <tt>@na1</tt>. Furthermore, when a name is not expressed on a
-      <tt>@na</tt> or <tt>@na1</tt> attribute, sometimes the attribute
-      is still present but just has no value. However, <tt>@na</tt>
+      <code>@na1</code>. Furthermore, when a name is not expressed on a
+      <code>@na</code> or <code>@na1</code> attribute, sometimes the attribute
+      is still present but just has no value. However, <code>@na</code>
       is only specified without a value for characters we should never
       see: DELETE and the PUA block.</xd:p>
     </xd:desc>
@@ -442,11 +445,10 @@
   </xd:doc>
   <xsl:template name="html_head">
     <head>
-      <xsl:variable name="title" select="'chars in '||$fileName"/>
-      <title><xsl:value-of select="'Character counts in '||$fileName"/></title>
+      <title xsl:expand-text="yes">Character counts in {$fileName}</title>
       <meta name="generated_by" content="table_of_Unicode_codepoint_counts.xslt"/>
       <meta name="generated_at" content="{current-dateTime()}"/>
-      <script type="application/javascript" src="http://www.wwp.neu.edu/utils/bin/javascript/sorttable.js"/>
+      <script type="application/javascript" src="https://www.wwp.neu.edu/utils/bin/javascript/sorttable.js"/>
       <style type="text/css">
         <xsl:text disable-output-escaping="yes">
             body {
@@ -493,14 +495,14 @@
     used, and indicates which were actually used.</xd:desc>
   </xd:doc>
   <xsl:template name="explain_params">
-    <p>Character counts in <tt><xsl:value-of
-      select="$fileName"/></tt><a href="#fn1">¹</a>, using the
-      following parameters:</p>
+  <p>Character counts in
+      <code xsl:expand-text="yes">{$fileName}</code><a href="#fn1">¹</a>,
+      using the following parameters:</p>
     <dl>
       <dt><span class="param">attrs</span></dt>
       <dd>
         <ul>
-          <li class="{$attrs eq 0}"><span class="val">0</span>: drop <emph>all</emph> attributes</li>
+          <li class="{$attrs eq 0}"><span class="val">0</span>: drop <em>all</em> attributes</li>
           <li class="{$attrs eq 1}"><span class="val">1</span>: 
             <xsl:choose>
               <xsl:when test="$input/tei:*">
@@ -514,7 +516,7 @@
                 </ul>
               </xsl:when>
               <xsl:when test="$input/wwp:* | $input/yaps:*">
-                keep only pre() and post() of @rend
+                keep only pre() and post() of @rend, and ignore keywords like “#rule” in those
               </xsl:when>
               <xsl:when test="$input/html:*">
                 keep only @title and @alt
@@ -527,7 +529,7 @@
               </xsl:otherwise>
             </xsl:choose> [default]
           </li>
-          <li class="{$attrs eq 9}"><span class="val">9</span>: keep <emph>all</emph> attributes</li>
+          <li class="{$attrs eq 9}"><span class="val">9</span>: keep <em>all</em> attributes</li>
         </ul>
       </dd>
       <dt><span class="param">fold</span></dt>
@@ -535,8 +537,7 @@
         <ul>
           <li class="{$fold eq 0}"><span class="val">0</span>: no case folding [default]</li>
           <li class="{$fold eq 1}"><span class="val">1</span>: case folding (upper to lower, but A–Z <em>only</em>)</li>
-          <li class="{$fold eq 2}"><span class="val">2</span>: case folding (including Greek, etc.) and also fold LATIN SMALL LETTER LONG S
-            into LATIN SMALL LETTER S</li>
+          <li class="{$fold eq 2}"><span class="val">2</span>: case folding (including Greek, etc.) and also fold LATIN SMALL LETTER LONG S into LATIN SMALL LETTER S</li>
         </ul>
       </dd>
       <dt><span class="param">skip</span></dt>
@@ -544,12 +545,12 @@
         <ul>
           <li class="{$skip eq 0}"><span class="val">0</span>: process entire document, including comments and processing instructions</li>
           <li class="{$skip eq 1}"><span class="val">1</span>: process entire document <em>excluding</em> comments and processing instructions</li>
-          <li class="{$skip eq 2}"><span class="val">2</span>: do 1, and also strip out metadata (<tt>&lt;teiHeader></tt> or <tt>&lt;html:head></tt>)</li>
-          <li class="{$skip eq 3}"><span class="val">3</span>: do 2, and also strip out printing artifacts, etc. (<tt>&lt;tei:fw></tt>, <tt>&lt;wwp:mw></tt>, <tt>&lt;figDesc></tt>) [default]</li>
-          <li class="{$skip eq 4}"><span class="val">4</span>: do 3, and also take <tt>&lt;corr&gt;</tt> over <tt>&lt;sic&gt;</tt>, <tt>&lt;expan&gt;</tt> over
-            <tt>&lt;abbr&gt;</tt>, <tt>&lt;reg&gt;</tt> over <tt>&lt;orig&gt;</tt> and the first <tt>&lt;supplied&gt;</tt> or
-            <tt>&lt;unclear&gt;</tt> in a <tt>&lt;choice&gt;</tt> (only makes sense for TEI and WWP; and for WWP this
-            means counting the regularized version of each <tt>&lt;vuji></tt> character)</li>
+          <li class="{$skip eq 2}"><span class="val">2</span>: do 1, and also strip out metadata (<code>&lt;teiHeader></code> or <code>&lt;html:head></code>)</li>
+          <li class="{$skip eq 3}"><span class="val">3</span>: do 2, and also strip out printing artifacts, etc. (<code>&lt;tei:fw></code>, <code>&lt;wwp:mw></code>, <code>&lt;figDesc></code>) [default]</li>
+          <li class="{$skip eq 4}"><span class="val">4</span>: do 3, and also take <code>&lt;corr&gt;</code> over <code>&lt;sic&gt;</code>, <code>&lt;expan&gt;</code> over
+            <code>&lt;abbr&gt;</code>, <code>&lt;reg&gt;</code> over <code>&lt;orig&gt;</code> and the first <code>&lt;supplied&gt;</code> or
+            <code>&lt;unclear&gt;</code> in a <code>&lt;choice&gt;</code> (only makes sense for TEI and WWP; and for WWP this
+            means counting the regularized version of each <code>&lt;vuji></code> character)</li>
         </ul>
       </dd>
       <dt><span class="param">whitespace</span></dt>


### PR DESCRIPTION
Replacement for PR #29, without the duplicate commit history. Years ago, I'd rewritten the entire commit history for this repository, and unfortunately Syd still had a copy with the original SHAs. This PR keeps his commits in place while maintaining the current repository history.

I used `git cherry-pick` to re-play @sydb's most recent commits (updating the `character_counts` XSLT) onto a new branch created off main. `git diff 89aeac9 9d711cd character_counts/table_of_Unicode_codepoint_counts.xslt` shows no difference between the XSLT as of commit 89aeac9 (new branch) and the XSLT as of commit 9d711cd (old branch).

When this PR is merged, PR #29 can be closed, and the `character_counts` branch deleted and/or replaced with the new one.